### PR TITLE
redirect xmllint's stderr to stdout expected by linter (closes #1)

### DIFF
--- a/lib/linter-xmllint.coffee
+++ b/lib/linter-xmllint.coffee
@@ -10,7 +10,7 @@ class LinterXmllint extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: 'xmllint --noout'
+  cmd: 'xmllint --noout @filename 2>&1'
 
   linterName: 'xmllint'
 


### PR DESCRIPTION
Note: There a `errorStream: 'stderr'` property, but doesn't seem to have any effect.

Closes #1
