### PR TITLE
support multiple schema as well as relaxng

### DIFF
--- a/spec/fixtures/invalid/multiple-errors.xml
+++ b/spec/fixtures/invalid/multiple-errors.xml
@@ -8,5 +8,6 @@
   <to>Tove</to>
   <from>Jani</from>
   <heading>Reminder</heading>
-  <body id="">Don't forget me this weekend!</body>
+  <body id="body">Don't forget me this weekend!</body>
+  <footer/>
 </note>

--- a/spec/fixtures/invalid/relax-errors.xml
+++ b/spec/fixtures/invalid/relax-errors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<?xml-model href="../note.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../note2.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<note>
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Don't forget me this weekend!</body>
+  <footer/>
+</note>

--- a/spec/fixtures/note.dtd
+++ b/spec/fixtures/note.dtd
@@ -7,3 +7,4 @@
 <!ELEMENT from (#PCDATA)>
 <!ELEMENT heading (#PCDATA)>
 <!ELEMENT body (#PCDATA)>
+<!ATTLIST body id CDATA #IMPLIED>

--- a/spec/fixtures/note.rng
+++ b/spec/fixtures/note.rng
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<element name="note" xmlns="http://relaxng.org/ns/structure/1.0">
+  <element name="to">
+    <text/>
+  </element>
+  <element name="from">
+    <text/>
+  </element>
+  <element name="heading">
+    <text/>
+  </element>
+  <element name="body">
+    <text/>
+  </element>
+</element>

--- a/spec/fixtures/note2.rng
+++ b/spec/fixtures/note2.rng
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<element name="note" xmlns="http://relaxng.org/ns/structure/1.0">
+  <element name="to">
+    <text/>
+  </element>
+  <element name="from">
+    <text/>
+  </element>
+  <element name="heading">
+    <text/>
+  </element>
+  <element name="footer">
+    <text/>
+  </element>
+</element>

--- a/spec/fixtures/valid/relax.xml
+++ b/spec/fixtures/valid/relax.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-model href="../note.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<note>
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Don't forget me this weekend!</body>
+</note>

--- a/spec/linter-xmllint-spec.coffee
+++ b/spec/linter-xmllint-spec.coffee
@@ -55,6 +55,10 @@ describe 'The xmllint provider for Linter', ->
       return atom.workspace.open(__dirname + '/fixtures/valid/all.xml').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 0
+    waitsForPromise ->
+      return atom.workspace.open(__dirname + '/fixtures/valid/relax.xml').then (editor) ->
+        return lint(editor).then (messages) ->
+          expect(messages.length).toEqual 0
 
   it 'finds something wrong with invalid files', ->
     waitsForPromise ->
@@ -89,48 +93,11 @@ describe 'The xmllint provider for Linter', ->
       return atom.workspace.open(__dirname + '/fixtures/invalid/xml-model-error.xml').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 1
-
-  # describe('checks bad.php and', () => {
-  #   let editor = null;
-  #   beforeEach(() => {
-  #     waitsForPromise(() => {
-  #       return atom.workspace.open(__dirname + '/files/bad.php').then(openEditor => {
-  #         editor = openEditor;
-  #       });
-  #     });
-  #   });
-
-  #   it('finds at least one message', () => {
-  #     waitsForPromise(() => {
-  #       return lint(editor).then(messages => {
-  #         expect(messages.length).toEqual(1);
-  #       });
-  #     });
-  #   });
-
-  #   it('verifies that message', () => {
-  #     waitsForPromise(() => {
-  #       return lint(editor).then(messages => {
-  #         expect(messages[0].type).toBeDefined();
-  #         expect(messages[0].type).toEqual('Error');
-  #         expect(messages[0].text).toBeDefined();
-  #         expect(messages[0].text).toEqual('syntax error, unexpected \'{\' in -');
-  #         expect(messages[0].filePath).toBeDefined();
-  #         expect(messages[0].filePath).toMatch(/.+bad\.php$/);
-  #         expect(messages[0].range).toBeDefined();
-  #         expect(messages[0].range.length).toEqual(2);
-  #         expect(messages[0].range).toEqual([[1, 0], [1, 6]]);
-  #       });
-  #     });
-  #   });
-  # });
-
-  # it('finds nothing wrong with a valid file', () => {
-  #   waitsForPromise(() => {
-  #     return atom.workspace.open(__dirname + '/files/good.php').then(editor => {
-  #       return lint(editor).then(messages => {
-  #         expect(messages.length).toEqual(0);
-  #       });
-  #     });
-  #   });
-  # })
+    waitsForPromise ->
+      return atom.workspace.open(__dirname + '/fixtures/invalid/relax-errors.xml').then (editor) ->
+        return lint(editor).then (messages) ->
+          expect(messages.length).toEqual 2
+    waitsForPromise ->
+      return atom.workspace.open(__dirname + '/fixtures/invalid/multiple-errors.xml').then (editor) ->
+        return lint(editor).then (messages) ->
+          expect(messages.length).toEqual 3


### PR DESCRIPTION
This patch uses all schemas for validation (not only the first one) and also allows relax ng (as requested in #29).