### PR TITLE
make warnings from the validator available rather then ignoring them

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -211,10 +211,17 @@ module.exports =
           messages = @parseSchematronMessages(textEditor, output)
         else
           messages = @parseSchemaMessages(textEditor, output)
-        for message in messages
-          message.type = 'Error'
-          message.text = message.text + ' (' + schemaUrl + ')'
-          message.filePath = textEditor.getPath()
+        if messages.length
+          for message in messages
+            message.type = 'Error'
+            message.text = message.text + ' (' + schemaUrl + ')'
+            message.filePath = textEditor.getPath()
+        else if output.indexOf('- validates') is -1
+          messages.push({
+            type: 'Error'
+            text: output
+            filePath: textEditor.getPath()
+          })
         return messages
 
   parseMessages: (output) ->

--- a/spec/fixtures/invalid/xml-model-unavailable.xml
+++ b/spec/fixtures/invalid/xml-model-unavailable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml-model href="../unavailable.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<note xmlns="http://www.w3schools.com">
+  <to>Tove</to>
+  <from>Jani</from>
+  <heading>Reminder</heading>
+  <body>Don't forget me this weekend!</body>
+</note>

--- a/spec/linter-xmllint-spec.coffee
+++ b/spec/linter-xmllint-spec.coffee
@@ -114,6 +114,12 @@ describe 'The xmllint provider for Linter', ->
           expect(messages.length).toEqual 1
           expect(messages[0].range).toEqual [[3, 2], [3, 21]]
     waitsForPromise ->
+      return atom.workspace.open(__dirname + '/fixtures/invalid/xml-model-unavailable.xml').then (editor) ->
+        return lint(editor).then (messages) ->
+          expect(messages.length).toEqual 1
+          expect(messages[0].range).toEqual undefined
+          expect(messages[0].text).toContain 'unavailable.xsd'
+    waitsForPromise ->
       return atom.workspace.open(__dirname + '/fixtures/invalid/relax-errors.xml').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 2


### PR DESCRIPTION
If e.g. `xmllint` fails to access a referenced xml-model file the warning was not visible to the user. If the validation fails the remaining output it always shown in a message.