### PR TITLE
Update Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,22 @@
+### Project specific config ###
+language: generic
+dist: trusty
+os: linux
+
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+before_script:
+  - xmllint --version
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
+
 notifications:
   email:
     on_success: never
@@ -7,37 +26,10 @@ branches:
   only:
     - master
 
-before_script:
-  - xmllint --version
-
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
 git:
   depth: 10
 
-
-matrix:
-  include:
-    - os: linux
-      env: ATOM_CHANNEL=stable
-      language: node_js
-      node_js: "5"
-      sudo: required
-      dist: trusty
-      install:
-        - sudo apt-get install libxml2-utils
-    - os: linux
-      env: ATOM_CHANNEL=beta
-      language: node_js
-      node_js: "5"
-      sudo: required
-      dist: trusty
-      install:
-        - sudo apt-get install libxml2-utils
-    - os: osx
-      env: ATOM_CHANNEL=stable
-      language: node_js
-      node_js: "5"
+sudo: false
 
 addons:
   apt:
@@ -46,3 +38,5 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+    # Necessary to get xmllint available
+    - libxml2-utils


### PR DESCRIPTION
* Updates the Travis-Ci config to match the current style of atom/ci
* Use the apt whitelist to install `libxml2-utils` for us in the container image
* Cut out macOS testing, the queue times make development unbearable and provide extremely little benefit